### PR TITLE
Video chat ui refactor

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -62,8 +62,9 @@ exports.onWorkspaceParticipantsChanged2 = functions.database.ref("/room/{classId
   workspaceRef.collection('participants').doc(userWhoLeft.uid).delete();
 })
 
-exports.onMainLobbyParticipantsChanged = functions.database.ref("/class/{classId}/participants").onWrite((change,context) => {
+exports.onClassParticipantsChanged = functions.database.ref("/class/{classId}/participants").onWrite((change,context) => {
   const userWhoLeft = change.after.val();
+  console.log("user", userWhoLeft)
   if (!userWhoLeft.uid) { return; }
   const { classId } = context.params;
   firestore.doc(`/classes/${classId}/participants/${userWhoLeft.uid}`).delete();

--- a/src/components/RealtimeAudio.vue
+++ b/src/components/RealtimeAudio.vue
@@ -140,13 +140,11 @@ export default {
 		}
 	},
 	created() {
-		console.log("audio created")
 		this.token = this.getAccessToken();
 	},
 	beforeDestroy () {
 		this.$emit('left-room');
 		this.leaveRoomIfJoined();
-		console.log('Audio destroyed',this.roomId)
 	},
 	methods: {
 		toggleMic () {
@@ -220,7 +218,6 @@ export default {
 		attachTrack(track, container, isLocal, init) {
 			this.detachTrack(track) //remove any duplicate tracks
 				if (track.kind === "video") {
-					console.log("TRAK", init, track)
 					
 					if (track.isStarted) {
 						scaleAndAttachVideo(track, container);

--- a/src/components/RealtimeAudio.vue
+++ b/src/components/RealtimeAudio.vue
@@ -1,7 +1,7 @@
 <template>
 	<div v-if="hasJoinedMedia">
-		<portal to="video-chat">
-			<v-container class="video-display">
+		<portal to="video-chat" :disabled="!portalToLiveBoard">
+			<v-container v-show="!isMinimizedView" class="video-display">
 				<v-row>
 					<v-col class="video-col">
 						<div class="video-container-wrapper">
@@ -35,7 +35,41 @@
 					</v-col>
 				</v-row>
 			</v-container>
+			<v-container v-show="isMinimizedView" class="video-display">
+				<v-row>
+					<v-col class="video-col">
+						<div class="mini-view-container">
+							<div class="display-bar">
+								<div class="name-container">
+									{{user.firstName + " " + user.lastName}}
+								</div>
+								<div class="local-buttons-container">
+									<v-btn @click="toggleMic()" x-small><v-icon small>{{isMicOn ? 'mdi-microphone': 'mdi-microphone-off'}}</v-icon></v-btn>
+									<v-btn @click="toggleCamera()" x-small ><v-icon small>{{isCameraOn ? 'mdi-video': 'mdi-video-off'}}</v-icon></v-btn>
+								</div>
+							</div>
+						</div>
+					</v-col>
+					<v-col v-for="participant in roomParticipants.filter(p => (p.uid !== user.uid) && p.hasJoinedMedia)" 
+						:key="participant.uid" 
+						class="video-col">
+						<div class="mini-view-container" >
+							<div  v-show="participant.isCameraOn" :id="`remote-media-${participant.uid}`"  class="video-container"/>
+							<v-icon v-show="!participant.isCameraOn" color="white" x-large style="width: 100%; height: 100%">mdi-video-off</v-icon>
+							<div class="display-bar">
+								<div class="name-container">
+									{{participant.firstName + " " + participant.lastName}}
+								</div>
+								<v-icon class="participant-mic">
+									{{participant.isMicOn ? 'mdi-microphone': 'mdi-microphone-off'}}
+								</v-icon> 
+							</div>
+						</div>
+					</v-col>
+				</v-row>
+			</v-container>
 		</portal>
+		<!-- <portal-target name="video-chat-global"/> -->
 	</div>
 </template> 
 
@@ -53,8 +87,9 @@ export default {
 		roomId: String,
 		classId: String,
 		hasJoinedMedia: Boolean,
-		blackboardRoom: Object,
-		roomParticipants: Array
+		roomParticipants: Array,
+		portalToLiveBoard: Boolean,
+		isMinimizedView: Boolean
 	},
 	data() {
 		return {
@@ -72,7 +107,7 @@ export default {
 			"user"
 		]),
 		roomParticipantRef () {
-			return db.doc(`classes/${this.classId}/blackboards/${this.roomId}/participants/${this.user.uid}`);
+			return db.doc(`classes/${this.classId}/participants/${this.user.uid}`);
 		}
 	},
 	watch: {
@@ -95,6 +130,11 @@ export default {
 			// immediate: true,
 			handler () {
 				this.updateMediaStatus();
+			}
+		},
+		portalToLiveBoard () {
+			if (this.activeRoom){
+				this.connectAllTracksInRoom(this.activeRoom)
 			}
 		}
 	},
@@ -139,7 +179,7 @@ export default {
 			}
 		},
 		updateMediaStatus () {
-			console.log("Updating db", this.isMicOn, this.isCameraOn, this.hasJoinedMedia)
+			// console.log("Updating db", this.isMicOn, this.isCameraOn, this.hasJoinedMedia)
 			if (this.roomParticipantRef){
 				this.roomParticipantRef.update({
 					isMicOn: this.isMicOn,
@@ -176,27 +216,30 @@ export default {
 				return jwt;
 		},
 		// Trigger log events 
-		attachTrack(track, container, isLocal=false) {
+		attachTrack(track, container, isLocal, init) {
+			this.detachTrack(track) //remove any duplicate tracks
 				if (track.kind === "video") {
-
+					console.log("TRAK", init, track)
+					
 					if (track.isStarted) {
 						scaleAndAttachVideo(track, container);
 					}
-
-					track.on('dimensionsChanged', (videoTrack) => { 
-						console.log("Track dimensions changed", videoTrack);
-						// scaleAndAttachVideo(track, container);
-					});
-					track.on('started', (videoTrack) => { 
-						console.log("Track started", videoTrack);
-						scaleAndAttachVideo(track, container);
-					});
+					
+					if (init){ //we dont want to set a bunch of event emitters
+						track.on('dimensionsChanged', (videoTrack) => { 
+							console.log("Track dimensions changed", videoTrack);
+							// scaleAndAttachVideo(track, container);
+						});
+						track.on('started', (videoTrack) => { 
+							console.log("Track started", videoTrack);
+							scaleAndAttachVideo(track, container);
+						});
+					}
 
 					function scaleAndAttachVideo (videoTrack, container) {
 						var videoTag = videoTrack.attach();
 						const videoHeight = videoTrack.dimensions.height;
 						const videoWidth = videoTrack.dimensions.width;
-						console.log("video dims", videoTrack, videoHeight, videoWidth)
 						const aspectRatio = videoWidth/videoHeight;
 						videoTag.setAttribute('style', 
 									`${aspectRatio < (16/9) ? 'height' : 'width'}: 100%; transform: ${isLocal ? 'scale(-1, 1)': ''}`)
@@ -212,9 +255,9 @@ export default {
 					container.appendChild(track.attach());
 				}
 		},
-		attachTracks(tracks, container, isLocal=false) {
+		attachTracks(tracks, container, isLocal=false, init=false) {
 				tracks.forEach((track) => {
-						this.attachTrack(track, container, isLocal);
+						this.attachTrack(track, container, isLocal, init);
 				});
 		},
 		detachTrack(track) {
@@ -224,11 +267,11 @@ export default {
 		},
 		trackPublished(publication, container) {
 				if (publication.isSubscribed) {
-						this.attachTrack(publication.track, container);
+						this.attachTrack(publication.track, container, false, true);
 				}
 				publication.on('subscribed', (track) => {
 						console.log('Subscribed to ' + publication.kind + ' track');
-						this.attachTrack(track, container);
+						this.attachTrack(track, container, false, true);
 				});
 				publication.on('unsubscribed', this.detachTrack);
 		},
@@ -317,7 +360,7 @@ export default {
 				
 				this.activeRoom = room;
 				var previewContainer = document.getElementById('local-media');
-				this.attachTracks(this.getTracks(room.localParticipant), previewContainer, true);
+				this.attachTracks(this.getTracks(room.localParticipant), previewContainer, true, true);
 				this.isMicOn = true;
 				this.isCameraOn = true;
 
@@ -348,6 +391,37 @@ export default {
 					room.participants.forEach(this.detachParticipantTracks);
 					this.activeRoom = null;
 				});
+		},
+		connectAllTracksInRoom (room) {
+			this.recurseNextTickLocal(room, 0);
+
+			room.participants.forEach((participant) => {
+				this.recurseNextTickRemote(room, participant, 0);
+			});
+		},
+		recurseNextTickLocal(room, count) {
+			if (count < 5){
+				this.$nextTick( () => {
+					var previewContainer = document.getElementById('local-media');
+					if (previewContainer) {
+						this.attachTracks(this.getTracks(room.localParticipant), previewContainer, true, false);
+						return;
+					}
+					this.recurseNextTickLocal(room, count+1)
+				})
+			}
+		},
+		recurseNextTickRemote(room, participant, count) {
+			if (count < 5){
+				this.$nextTick( () => {
+					var previewContainer = document.getElementById(`remote-media-${participant.identity}`);
+					if (previewContainer) {
+						this.attachTracks(this.getTracks(participant), previewContainer, false, false);
+						return;
+					}
+					this.recurseNextTickRemote(room, participant, count+1)
+				})
+			}
 		}
 	}
 }
@@ -361,6 +435,7 @@ export default {
 	opacity: 1;
 	z-index: 1000;
 	padding-bottom: 0;
+	padding-top: 0;
 	margin-left: 0%;
 }
 .video-col{
@@ -415,5 +490,14 @@ export default {
 	right: 0px;
 	color: white; 
 	bottom: 0px;
+}
+.mini-view-container{
+	height: 30px;
+	width: 240px;
+	position: relative;
+	border-style: solid;
+	border-color: var(--v-accent-base);
+	background-color:black;
+	border-radius: 10px;
 }
 </style>

--- a/src/components/RealtimeAudio.vue
+++ b/src/components/RealtimeAudio.vue
@@ -17,11 +17,11 @@
 							</div>
 						</div>
 					</v-col>
-					<v-col v-for="participant in roomParticipants.filter(p => (p.uid !== user.uid) && p.hasJoinedMedia)" 
-						:key="participant.uid" 
+					<v-col v-for="participant in roomParticipants.filter(p => (p.rToken !== rToken) && p.hasJoinedMedia)" 
+						:key="participant.rToken" 
 						class="video-col">
 						<div class="video-container-wrapper" >
-							<div  v-show="participant.isCameraOn" :id="`remote-media-${participant.uid}`"  class="video-container"/>
+							<div  v-show="participant.isCameraOn" :id="`remote-media-${participant.rToken}`"  class="video-container"/>
 							<v-icon v-show="!participant.isCameraOn" color="white" x-large style="width: 100%; height: 100%">mdi-video-off</v-icon>
 							<div class="display-bar">
 								<div class="name-container">
@@ -50,11 +50,11 @@
 							</div>
 						</div>
 					</v-col>
-					<v-col v-for="participant in roomParticipants.filter(p => (p.uid !== user.uid) && p.hasJoinedMedia)" 
-						:key="participant.uid" 
+					<v-col v-for="participant in roomParticipants.filter(p => (p.rToken !== rToken) && p.hasJoinedMedia)" 
+						:key="participant.rToken" 
 						class="video-col">
 						<div class="mini-view-container" >
-							<div  v-show="participant.isCameraOn" :id="`remote-media-${participant.uid}`"  class="video-container"/>
+							<div  v-show="participant.isCameraOn" :id="`remote-media-${participant.rToken}`"  class="video-container"/>
 							<v-icon v-show="!participant.isCameraOn" color="white" x-large style="width: 100%; height: 100%">mdi-video-off</v-icon>
 							<div class="display-bar">
 								<div class="name-container">
@@ -104,10 +104,11 @@ export default {
 	},
 	computed: {
 	...mapState([
-			"user"
+			"user",
+			"rToken"
 		]),
 		roomParticipantRef () {
-			return db.doc(`classes/${this.classId}/participants/${this.user.uid}`);
+			return db.doc(`classes/${this.classId}/participants/${this.rToken}`);
 		}
 	},
 	watch: {
@@ -204,7 +205,7 @@ export default {
 						API_KEY_SECRET
 				);
 
-				accessToken.identity = this.user.uid;
+				accessToken.identity = this.rToken;
 
 				// Grant access to Video
 				var grant = new VideoGrant();

--- a/src/components/TheSideDrawer.vue
+++ b/src/components/TheSideDrawer.vue
@@ -32,7 +32,8 @@
         </v-tab-item>
     
         <v-tab-item v-if="user" value="rooms">
-          <TheSideDrawerSpaces/>
+          <TheSideDrawerSpaces
+            :roomParticipantsMap="roomParticipantsMap"/>
         </v-tab-item>
       </v-tabs-items>
     </v-navigation-drawer>
@@ -49,7 +50,8 @@ import { mapState } from "vuex";
 
 export default {
   props: {
-    value: Boolean
+    value: Boolean,
+    roomParticipantsMap: Object
   },
   components: {
     TheSideDrawerFileExplorer,

--- a/src/components/TheSideDrawerSpaces.vue
+++ b/src/components/TheSideDrawerSpaces.vue
@@ -43,11 +43,11 @@
                         <template v-for="(participant, i) in roomParticipantsMap[blackboard.id]">
                           <div class="d-flex align-center py-2" :key="i">
                             <v-icon>mdi-account</v-icon>
-                            <div :class="['pl-1', 'col', 'py-0', participant.uid === user.uid ? 'font-weight-bold':'']">
+                            <div :class="['pl-1', 'col', 'py-0', participant.rToken === rToken ? 'font-weight-bold':'']">
                               {{ participant.firstName }}
                             </div>
 
-                            <template v-if="user.uid === participant.uid">
+                            <template v-if="participant.rToken === rToken">
                               <BaseButton @click="roomStatusPopup = true" outlined rounded icon="mdi-account-alert">
                                 Re-label Space
                               </BaseButton>
@@ -174,7 +174,8 @@ export default {
     ...mapState([
       "user",
       "blackboardRoom",
-      "mitClass"
+      "mitClass",
+      "rToken"
     ]),
     classID () {
       return this.$route.params.class_id;

--- a/src/components/TheSideDrawerSpaces.vue
+++ b/src/components/TheSideDrawerSpaces.vue
@@ -77,7 +77,7 @@
                                 </v-card>
                               </v-dialog>
                                                 
-                              <BaseButton @click="hasJoinedMedia=!hasJoinedMedia" 
+                              <!-- <BaseButton @click="hasJoinedMedia=!hasJoinedMedia" 
                                 :color="hasJoinedMedia ? 'accent' : 'accent lighten-1'" 
                                 :outlined="hasJoinedMedia" 
                                 rounded
@@ -89,7 +89,7 @@
                                 </template>
                                 
                                 <template v-else>Exit Video Chat</template>
-                              </BaseButton>
+                              </BaseButton> -->
                             </template>
                             <template v-else>
                               <v-icon style="right: 7%">{{participant.isMicOn ? 'mdi-microphone': 'mdi-microphone-off'}}</v-icon>
@@ -125,18 +125,6 @@
       @create-blackboard="roomType => createBlackboard(roomType)"
     />
   </v-list>
-
-  <!-- TODO: refactor -->
-    <RealtimeAudio v-if="user"
-      :roomId="lastBlackboardRoomId"
-      :classId="classID"
-      :roomParticipants="roomParticipantsMap[lastBlackboardRoomId]"
-      :hasJoinedMedia="hasJoinedMedia"
-      :blackboardRoom="blackboardRoom"
-      :key="lastBlackboardRoomId"
-      @left-room="hasJoinedMedia = false; hasLoadedMedia = false;"
-      @media-connected="hasLoadedMedia = true"
-    />
   </div>
 </template>
 
@@ -153,6 +141,9 @@ import { mapState } from "vuex";
 import Vue from 'vue';
 
 export default {
+  props: {
+    roomParticipantsMap: Object
+  },
   mixins: [
     DatabaseHelpersMixin
   ],
@@ -167,15 +158,14 @@ export default {
       snapshotListeners: [],
       centerTableParticipants: [],
       blackboards: [],
-      hasLoadedMedia: false,
-      hasJoinedMedia: false,
+      // hasLoadedMedia: false,
+      // hasJoinedMedia: false,
       savedRoomId: "",
       roomTypes: [],
       roomCategories: [],
       expandedPanels: [],
       roomStatusPopup: false,
       updatedStatus: "",
-      roomParticipantsMap: {},
       mitClassDoc: {},
       isCreatePopupOpen: false,
     };
@@ -192,15 +182,6 @@ export default {
     roomID () {
       return this.$route.params.room_id;
     },
-    lastBlackboardRoomId () {
-      if (this.roomID) {
-        this.savedRoomId = this.roomID;
-      }
-      return this.savedRoomId;
-    },
-    numberOfBlackboards () {
-      return this.blackboards.length
-    }
   },
   watch: {
     blackboards () {
@@ -217,17 +198,6 @@ export default {
         const ind = this.roomTypes.indexOf(this.blackboardRoom.roomType)
         this.expandedPanels = [ind]
       }
-    },
-    // TODO
-    numberOfBlackboards () {
-      this.blackboards.forEach(blackboard => {
-        const blackboardsRef = db.collection(`classes/${this.classID}/blackboards`);
-        const participantsRef = blackboardsRef.doc(blackboard.id).collection("participants");
-        Vue.set(this.roomParticipantsMap, blackboard.id, []); // this makes each entry in the object reactive.
-        this.$_listenToCollection(participantsRef, this.roomParticipantsMap, blackboard.id).then(snapshotListener => {
-          this.snapshotListeners.push(snapshotListener);
-        });
-      })
     }
   },
   created () {

--- a/src/pages/ClassPage.vue
+++ b/src/pages/ClassPage.vue
@@ -64,9 +64,56 @@
       </template>
     </TheAppBar>
 
-    <TheSideDrawer v-model="drawer"/>
-
-    <!-- Router View -->
+    <TheSideDrawer
+      v-model="drawer"
+      :roomParticipantsMap="roomParticipantsMap"/>
+    <div v-if="lastBlackboardRoomId" class="video-chat-container">
+        <RealtimeAudio 
+          v-if="user"
+          :roomId="lastBlackboardRoomId"
+          :classId="classID"
+          :roomParticipants="roomParticipantsMap[lastBlackboardRoomId]"
+          :portalToLiveBoard="portalToLiveBoard"
+          :hasJoinedMedia="hasJoinedMedia"
+          :isMinimizedView="isMinimizedView"
+          @left-room="hasJoinedMedia=false; hasLoadedMedia=false;"
+          @media-connected="hasLoadedMedia=true"
+          :key="lastBlackboardRoomId"
+          class="video-component"
+        />
+      <BaseButton @click="hasJoinedMedia=!hasJoinedMedia" 
+        :color="hasJoinedMedia ? 'accent' : 'accent lighten-1'" 
+        :outlined="hasJoinedMedia" 
+        rounded
+        :icon="hasJoinedMedia ? 'mdi-video': 'mdi-video-off'"
+      >
+        <template v-if="!hasLoadedMedia">
+          <template v-if="!hasJoinedMedia">Join Video Chat</template>
+          <v-progress-circular v-else indeterminate size="20" width="2"/>
+        </template>
+        
+        <template v-else>Exit Video Chat</template>
+      </BaseButton>
+      <template v-if="hasLoadedMedia">
+        <BaseButton @click="handleVideoViewToggle()" 
+          color='accent'
+          rounded
+          outlined
+          :icon="portalToLiveBoard ? 'mdi-chevron-double-down' : 'mdi-chevron-double-up'"
+        >
+        {{portalToLiveBoard ? 'Display In Corner' : 'Display in Board'}}
+        </BaseButton>
+        <BaseButton
+          @click="isMinimizedView = !isMinimizedView"
+          color='accent'
+          rounded
+          outlined
+          :icon="isMinimizedView ? 'mdi-arrow-expand' : 'mdi-arrow-collapse'"
+        >
+          {{isMinimizedView ? 'Normal View' : 'Mini View'}}
+        </BaseButton>
+      </template>
+    </div>
     <v-content>
       <RouterView :key="$route.fullPath"/>
     </v-content>
@@ -80,17 +127,21 @@ import TheAppBar from "@/components/TheAppBar.vue";
 import TheDropdownMenu from "@/components/TheDropdownMenu.vue";
 import BaseButton from "@/components/BaseButton.vue";
 import BasePopupButton from "@/components/BasePopupButton.vue";
+import RealtimeAudio from "@/components/RealtimeAudio.vue";
 import db from "@/database.js";
 import firebase from "firebase/app";
 import "firebase/firestore";
 import "firebase/auth";
 import AuthHelpers from "@/mixins/AuthHelpers.js";
+import DatabaseHelpersMixin from "@/mixins/DatabaseHelpersMixin.js";
 import { DefaultEmailSettings } from "@/CONSTANTS.js";
 import { mapState } from "vuex";
+import Vue from 'vue';
 
 export default {
   mixins: [
     AuthHelpers,
+    DatabaseHelpersMixin
   ],
   components: { 
     TheSideDrawer,
@@ -98,10 +149,20 @@ export default {
     TheDropdownMenu,
     MenuEmailSettings,
     BaseButton,
-    BasePopupButton
+    BasePopupButton,
+    RealtimeAudio
   },
   data: () => ({
-    drawer: true
+    drawer: true,
+    blackboards: [],
+    snapshotListeners: [],
+    roomParticipantsMap: {},
+    hasJoinedMedia: false,
+    hasLoadedMedia: false,
+    portalToLiveBoard: false,
+    firebaseRef: null,
+    classParticipantsRef: null,
+    isMinimizedView: false
   }),
   computed: {
     ...mapState([
@@ -112,9 +173,65 @@ export default {
       if (!this.user) return; 
       if (!this.user.enrolledClasses) return; 
       return this.user.enrolledClasses.filter((course) => course.id === this.$route.params.class_id).length === 1;
+    },
+    classID () {
+      return this.$route.params.class_id;
+    },
+    roomID () {
+      return this.$route.params.room_id;
+    },
+    lastBlackboardRoomId () {
+      if (this.roomID) {
+        this.savedRoomId = this.roomID;
+      }
+      else{
+        this.portalToLiveBoard = false;
+      }
+      return this.savedRoomId;
+    },
+    numberOfBlackboards () {
+      return this.blackboards.length;
     }
   },
+  watch : {
+    numberOfBlackboards () {
+      this.blackboards.forEach( blackboard => {
+        const roomParticipantsRef = this.classParticipantsRef.where("currentRoom", "==", blackboard.id);
+        Vue.set(this.roomParticipantsMap, blackboard.id, []) //this makes each entry in the object reactive.
+        this.$_listenToCollection(roomParticipantsRef, this.roomParticipantsMap, blackboard.id).then(snapshotListener => {
+          this.snapshotListeners.push(snapshotListener);
+        });
+      })
+    }
+  },
+  created () {
+    this.classParticipantsRef = db.collection(`classes/${this.classID}/participants`)
+    const blackboardsRef = db.collection(`classes/${this.classID}/blackboards`);
+    this.$_listenToCollection(blackboardsRef, this, "blackboards").then(snapshotListener => {
+      this.snapshotListeners.push(snapshotListener);
+    });
+    this.setUserDisconnectHook();
+  },
+  beforeDestroy () {
+    firebase.database().ref(".info/connected").off();
+    for (const detachListener of this.snapshotListeners) {
+      detachListener();
+    };
+    this.classParticipantsRef.doc(this.user.uid).delete()
+    this.firebaseRef.onDisconnect().cancel();
+  },
   methods: {
+    handleVideoViewToggle () {
+      if (!this.hasLoadedMedia && this.hasJoinedMedia){
+        return;
+      }
+      if (this.roomID){
+        this.portalToLiveBoard = !this.portalToLiveBoard;
+      }
+      else{
+        this.portalToLiveBoard = false;
+      }
+    },
     async updateSettings (payload) {
       const userRef = db.doc(`users/${this.user.uid}`);
       userRef.update({ 
@@ -133,6 +250,39 @@ export default {
       });
       this.$router.push({path: '/'});
       this.$root.$emit("show-snackbar", "Successfully dropped class.");
+    },
+    /**
+     * Push the user object onto the room's `participants` array, and ensures that 
+     * Firebase will remove the user object if he/she disconnects for whatever reason.
+     * 
+     * @see https://explain.mit.edu/class/mDbUrvjy4pe8Q5s5wyoD/posts/2srLvmhGXPVtmgNyNeCH
+     * @see https://firebase.google.com/docs/firestore/solutions/presence
+     * @see https://firebase.google.com/docs/database/web/offline-capabilities
+     */
+    setUserDisconnectHook () {
+      // ".info/connected" is a special location on Firebase Realtime Database 
+      // that keeps track of whether the current client is conneceted or disconnected (see doc above)
+      firebase.database().ref(".info/connected").on("value", async snapshot => {
+        const isUserConnected = snapshot.val(); 
+        if (isUserConnected === false){
+          return;
+        } 
+        this.firebaseRef = firebase.database().ref(`/class/${this.classID}/participants`);
+        // 1. User leaves, and his/her identity is saved to Firebase
+        // 2. Firestore detects the new user in Firebase, and uses that information to `arrayRemove` the user from the room
+        
+        // step 1 (step 2 is executed in Cloud Functions)
+        await this.firebaseRef.onDisconnect().set({ uid: this.user.uid });
+
+        //user hasn't always been fetched, but uid and email are set
+        console.log("Class Page set DC hook", this.user)
+        
+        this.firebaseRef.set({ // Firebase will not detect change if it's set to an empty object
+          email: "", 
+          uid: "", 
+          firstName: "" 
+        });
+      });
     }
   }
 }
@@ -143,6 +293,30 @@ export default {
 html {
   overflow-y: auto; 
 }
+.video-chat-container{
+  /* border-style: solid;  */
+  border-radius: 10px;
+  z-index: 100; 
+  position: fixed; 
+  right: 0px; 
+  bottom: 0px; 
+  background-color: #eee;
+  /* height: 300px;
+  width: 500px; */
+}
+/* .video-chat-container .video-component{
+  position: absolute; 
+  margin-top: 50px;
+  top: 0px;
+  right: 0px;
+  bottom: 0px;
+  margin-bottom: 50px;
+}
+.minimize-video-btn{
+  position: absolute;
+  top:0%;
+  right:0%;
+} */
 </style>
 
 

--- a/src/pages/ClassPage.vue
+++ b/src/pages/ClassPage.vue
@@ -167,7 +167,8 @@ export default {
   computed: {
     ...mapState([
       "user",
-      "mitClass"
+      "mitClass",
+      "rToken"
     ]),
     isUserEnrolled () {
       if (!this.user) return; 
@@ -217,7 +218,7 @@ export default {
     for (const detachListener of this.snapshotListeners) {
       detachListener();
     };
-    this.classParticipantsRef.doc(this.user.uid).delete()
+    this.classParticipantsRef.doc(this.rToken).delete()
     this.firebaseRef.onDisconnect().cancel();
   },
   methods: {
@@ -272,7 +273,7 @@ export default {
         // 2. Firestore detects the new user in Firebase, and uses that information to `arrayRemove` the user from the room
         
         // step 1 (step 2 is executed in Cloud Functions)
-        await this.firebaseRef.onDisconnect().set({ uid: this.user.uid });
+        await this.firebaseRef.onDisconnect().set({ uid: this.rToken });
 
         //user hasn't always been fetched, but uid and email are set
         console.log("Class Page set DC hook", this.user)

--- a/src/pages/ClassPageLectureHall.vue
+++ b/src/pages/ClassPageLectureHall.vue
@@ -167,11 +167,6 @@ export default {
             const isSameRoom = userObj.currentRoom === this.roomId;
             console.log("doc exists!", userObj)
             participantRef.update({
-              rToken: this.rToken,
-              uid: this.user.uid,
-              email: this.user.email,
-              firstName: this.user.firstName,
-              lastName: this.user.lastName,
               currentRoom: "lecture-hall",
               isMicOn: isSameRoom ? userObj.isMicOn : false,
               isCameraOn: isSameRoom ? userObj.isCameraOn : false,

--- a/src/pages/ClassPageRealtimeSpace.vue
+++ b/src/pages/ClassPageRealtimeSpace.vue
@@ -99,11 +99,6 @@ export default {
             const isSameRoom = userObj.currentRoom === this.roomId;
             console.log("doc exists!", userObj)
             participantRef.update({
-              rToken: this.rToken,
-              uid: this.user.uid,
-              email: this.user.email,
-              firstName: this.user.firstName,
-              lastName: this.user.lastName,
               currentRoom: this.roomId,
               isMicOn: isSameRoom ? userObj.isMicOn : false,
               isCameraOn: isSameRoom ? userObj.isCameraOn : false,

--- a/src/pages/ClassPageRealtimeSpace.vue
+++ b/src/pages/ClassPageRealtimeSpace.vue
@@ -42,7 +42,8 @@ export default {
   computed: {
     ...mapState([
       "user",
-      "mitClass"
+      "mitClass",
+      "rToken",
     ]),
     simplifiedUser () {
       if (!this.user) return; 

--- a/src/pages/ClassPageRealtimeSpace.vue
+++ b/src/pages/ClassPageRealtimeSpace.vue
@@ -30,6 +30,7 @@ export default {
       roomParticipants: [],
       snapshotListeners: [],
       roomRef: null,
+      classRef: null,
       roomParticipantsRef: null,
       strokesRef: null,
       unsubscribeRoomListener: null,
@@ -37,6 +38,8 @@ export default {
       roomId: this.$route.params.room_id,
       firebaseRef: null,
       messagesOpen: false,
+      hasUserBeenSet: false,
+      removeSetParticipantListener: null,
     }
   },
   computed: {
@@ -63,7 +66,9 @@ export default {
   },
   async created () {
     this.roomRef = db.doc(`classes/${this.classId}/blackboards/${this.roomId}`);
-    this.roomParticipantsRef = this.roomRef.collection("participants");
+    this.classRef = db.doc(`classes/${this.classId}`);
+    this.roomParticipantsRef = db.collection(`classes/${this.classId}/participants`).where("currentRoom", "==", this.roomId)
+
     this.strokesRef = this.roomRef.collection("strokes");
 
     this.unsubscribeRoomListener = await this.$_listenToDoc(this.roomRef, this, "room"); 
@@ -71,57 +76,54 @@ export default {
     this.$_listenToCollection(this.roomParticipantsRef, this, "roomParticipants").then(snapshotListener => {
       this.snapshotListeners.push(snapshotListener);
     });
-
-    this.setUserDisconnectHook();
+    this.setParticipant();
   },
   beforeDestroy () {
-    firebase.database().ref(".info/connected").off();
     this.unsubscribeRoomListener();
-    // this.roomRef.update({ //Filters out the current user
-    //   participants: this.room.participants.filter(participant => participant.uid !== this.user.uid) 
-    // });
     for (const detachListener of this.snapshotListeners) {
       detachListener();
     }
-    this.roomParticipantsRef.doc(this.user.uid).delete();
-    this.firebaseRef.onDisconnect().cancel();
+    firebase.database().ref(".info/connected").off();
   },
   methods: {
-    /**
-     * Push the user object onto the room's `participants` array, and ensures that 
-     * Firebase will remove the user object if he/she disconnects for whatever reason.
-     * 
-     * @see https://explain.mit.edu/class/mDbUrvjy4pe8Q5s5wyoD/posts/2srLvmhGXPVtmgNyNeCH
-     * @see https://firebase.google.com/docs/firestore/solutions/presence
-     * @see https://firebase.google.com/docs/database/web/offline-capabilities
-     */
-    setUserDisconnectHook () {
-      // ".info/connected" is a special location on Firebase Realtime Database 
-      // that keeps track of whether the current client is conneceted or disconnected (see doc above)
+    setParticipant() {
       firebase.database().ref(".info/connected").on("value", async snapshot => {
         const isUserConnected = snapshot.val(); 
         if (isUserConnected === false){
           return;
         } 
-        this.firebaseRef = firebase.database().ref(`/room/${this.classId}/${this.roomId}/participants`);
-        // 1. User leaves, and his/her identity is saved to Firebase
-        // 2. Firestore detects the new user in Firebase, and uses that information to `arrayRemove` the user from the room
+        const participantRef = db.doc(`classes/${this.classId}/participants/${this.user.uid}`);
+        participantRef.get().then(doc => {
+          if (doc.exists){
+            const userObj = doc.data();
+            const isSameRoom = userObj.currentRoom === this.roomId;
+            console.log("doc exists!", userObj)
+            participantRef.update({
+              uid: this.user.uid,
+              email: this.user.email,
+              firstName: this.user.firstName,
+              lastName: this.user.lastName,
+              currentRoom: this.roomId,
+              isMicOn: isSameRoom ? userObj.isMicOn : false,
+              isCameraOn: isSameRoom ? userObj.isCameraOn : false,
+              hasJoinedMedia: isSameRoom ? userObj.hasJoinedMedia : false,
+            })
+          }
+          else{
+            console.log("doc no exist")
+            participantRef.set({
+              uid: this.user.uid,
+              email: this.user.email,
+              firstName: this.user.firstName,
+              lastName: this.user.lastName,
+              currentRoom: this.roomId,
+              isMicOn: false,
+              isCameraOn: false,
+              hasJoinedMedia: false
+            })
+          }
+        })
         
-        // step 1 (step 2 is executed in Cloud Functions)
-        await this.firebaseRef.onDisconnect().set(this.simplifiedUser);
-
-        // add the current user to the lounge
-        this.roomParticipantsRef.doc(this.user.uid).set({
-          ...this.simplifiedUser,
-          isMicOn: false,
-          isCameraOn: false,
-          hasJoinedMedia: false
-        }); 
-        this.firebaseRef.set({ // Firebase will not detect change if it's set to an empty object
-          email: "", 
-          uid: "", 
-          firstName: "" 
-        });
       });
     }
   }

--- a/src/pages/ClassPageRealtimeSpace.vue
+++ b/src/pages/ClassPageRealtimeSpace.vue
@@ -92,13 +92,14 @@ export default {
         if (isUserConnected === false){
           return;
         } 
-        const participantRef = db.doc(`classes/${this.classId}/participants/${this.user.uid}`);
+        const participantRef = db.doc(`classes/${this.classId}/participants/${this.rToken}`);
         participantRef.get().then(doc => {
           if (doc.exists){
             const userObj = doc.data();
             const isSameRoom = userObj.currentRoom === this.roomId;
             console.log("doc exists!", userObj)
             participantRef.update({
+              rToken: this.rToken,
               uid: this.user.uid,
               email: this.user.email,
               firstName: this.user.firstName,
@@ -112,6 +113,7 @@ export default {
           else{
             console.log("doc no exist")
             participantRef.set({
+              rToken: this.rToken,
               uid: this.user.uid,
               email: this.user.email,
               firstName: this.user.firstName,

--- a/src/store.js
+++ b/src/store.js
@@ -50,7 +50,8 @@ export default new Vuex.Store({
     isFetchingUser: true,
     mitClass: null,
     explCache: {},
-    blackboardRoom: null
+    blackboardRoom: null,
+    rToken: ""
   },
   mutations: {
     SET_USER (state, user) {
@@ -62,6 +63,9 @@ export default new Vuex.Store({
     },
     SET_ROOM (state, blackboardRoom) {
       state.blackboardRoom = blackboardRoom; 
+    },
+    SET_RTOKEN (state, refreshToken){
+      state.rToken = refreshToken;
     },
     /**
      * Saves an explanation to the global cache so it can be accessed and uploaded to Firestore in the app background
@@ -86,8 +90,9 @@ export default new Vuex.Store({
       });
     },
     // Fetches the user document, binds it to a variable accessible by all components and listens for any changes
-    async fetchUser (context, { uid, email }) {
+    async fetchUser (context, { uid, email, refreshToken }) {
       if (!uid) return;
+      context.commit('SET_RTOKEN', refreshToken);
       context.commit('SET_USER', { uid, email }); // commit the user as soon as basic info has been fetched to avoid blocking page load
       const mirrorUserRef = db.collection('users').doc(uid);
       syncUserWithDb(mirrorUserRef, context);

--- a/src/store.js
+++ b/src/store.js
@@ -92,7 +92,6 @@ export default new Vuex.Store({
     // Fetches the user document, binds it to a variable accessible by all components and listens for any changes
     async fetchUser (context, { uid, email, refreshToken }) {
       if (!uid) return;
-      console.log(refreshToken, "SUB", refreshToken.substring(refreshToken.length-20))
       context.commit('SET_RTOKEN', refreshToken.substring(refreshToken.length-20));
       context.commit('SET_USER', { uid, email }); // commit the user as soon as basic info has been fetched to avoid blocking page load
       const mirrorUserRef = db.collection('users').doc(uid);

--- a/src/store.js
+++ b/src/store.js
@@ -92,7 +92,8 @@ export default new Vuex.Store({
     // Fetches the user document, binds it to a variable accessible by all components and listens for any changes
     async fetchUser (context, { uid, email, refreshToken }) {
       if (!uid) return;
-      context.commit('SET_RTOKEN', refreshToken);
+      console.log(refreshToken, "SUB", refreshToken.substring(refreshToken.length-20))
+      context.commit('SET_RTOKEN', refreshToken.substring(refreshToken.length-20));
       context.commit('SET_USER', { uid, email }); // commit the user as soon as basic info has been fetched to avoid blocking page load
       const mirrorUserRef = db.collection('users').doc(uid);
       syncUserWithDb(mirrorUserRef, context);


### PR DESCRIPTION
- Video can now be placed in right bottom Corner
- Video has mini-mode that "minimizes" video
- Join audio button and other controls are in bottom right
- video and user persist when moving around class tabs
- ^This was accomplished by a refactor of participants in classes. They are now stored in the class participants collection and have a property 'currentRoom' which denotes the current/previous room the participant was in.
- Uses refreshToken to distinguish between devices. Participants in live spaces are no longer indentified by uid but by rToken
