### PR TITLE
Fix blackboard concurrency bugs

### DIFF
--- a/src/components/Blackboard.vue
+++ b/src/components/Blackboard.vue
@@ -36,7 +36,7 @@
           
           <template v-slot:record-audio-slot>
             <slot name="blackboard-toolbar">
-
+            
             </slot> 
 
             <template v-if="currentState === RecordState.PRE_RECORD">
@@ -51,17 +51,24 @@
                 Add Background
               </BaseButton>
 
-              <!-- Reset button -->
-              <BasePopupButton actionName="Wipe board" @action-do="resetBoard()">
-                <template v-slot:activator-button="{ on }">
-                  <BaseButton :on="on" icon="mdi-delete" data-qa="wipe-board">
-                    Wipe Board
-                  </BaseButton>
-                </template>
-                <template v-slot:message-to-user>
-                  Are you sure you want to wipe everything?
-                </template> 
-              </BasePopupButton>
+              <!-- WIPE BOARD BUTTON -->
+              <!-- 
+                The slot below allows `RealtimeBlackboard.vue` to override behavior of "Wipe board";
+                Instead of wiping immediately, it wait until Firestore resolves the deletion request
+                before setting `strokesArray = []` to wipe the UI. 
+              -->
+              <slot name="wipe-board-button-slot"> 
+                <BasePopupButton actionName="Wipe board" @action-do="resetBoard()">
+                  <template v-slot:activator-button="{ on }">
+                    <BaseButton :on="on" icon="mdi-delete" data-qa="wipe-board">
+                      Wipe board
+                    </BaseButton>
+                  </template>
+                  <template v-slot:message-to-user>
+                    Are you sure you want to wipe everything?
+                  </template> 
+                </BasePopupButton>
+              </slot> 
 
               <!-- Record Button -->
               <BaseButton @click="startRecording()" icon="mdi-adjust" filled>

--- a/src/components/BlackboardCoreDrawing.vue
+++ b/src/components/BlackboardCoreDrawing.vue
@@ -5,10 +5,10 @@
       :isFullScreen="isFullScreen"
       :changeTool="changeTool"
       :handleImageFile="handleImageFile"
-      :resetBoard="resetBoard"
+      :resetBoard="resetBlackboard"
       :toggleFullScreen="toggleFullScreen"
       :setTouchDisabled="setTouchDisabled"
-      :touchDisabled="touchDisabled"
+      :touchDisabled="onlyAllowApplePencil"
     >
 
     </slot>
@@ -16,7 +16,7 @@
       <canvas ref="FrontCanvas" class="front-canvas" data-qa="front-canvas"
         @touchstart="e => touchStart(e)"
         @touchmove="e => touchMove(e)"
-        @touchend="e => touchEnd(e)"
+        @touchend="e => handleLiftingContactFromBlackboard(e)"
         @mousedown="e => mouseDown(e)"
         @mousemove="e => mouseMove(e)"
         @mouseup="e => mouseUp(e)"
@@ -34,13 +34,15 @@
  * then the canvas UI will diverge from `strokesArray` (part of the stroke will be cut-off).
  * However, this issue is minor in most practical situations, so will be ignored for now. 
  * 
- * Note that the local array and client array can deviate by 1 stroke (represents lag for example in the case of a realtime blackboard)
- *   localStrokesArray ahead: realtime database hasn't updated 
- *   clientStrokesArray ahead: client wants to add a stroke programmaticaly on the canvas
- * 
  * Maintains the invariant that the UI exactly reflects the strokesArray (see proof):
  * 
- * strokesArray => UI:
+ * Start state: initially, strokesArray is empty, and the canvas is blank
+ * Transition states: 
+ *   1. `strokesArray` gets modified 
+ *   2. The user draws a stroke on the the canvas
+ *   3. The canvas resizes 
+ * 
+ * 1. strokesArray => UI:
  *     case 1: a new stroke is pushed to `strokesArray`
  *         The watcher will draw it onto <canvas/> * and call `localStrokesArray.push(newStroke)`. 
  * 
@@ -49,11 +51,15 @@
  * 
  *     Note that mutating / deleting existing strokes are both disallowed (which will be enforced by an ADT later).
  * 
- * UI => strokesArray:
- *     No matter how the user draws, `saveStrokeThenReset()` is called:
- *     DANGER (TODO: refactor): eraser strokes does NOT pass `saveStrokeThenReset()`
+ * 2. UI => strokesArray:
+ *     No matter how the user draws, `handleEndOfStroke()` is called:
+ *     DANGER (TODO: refactor): eraser strokes does NOT pass `handleEndOfStroke()`
  *         1. $emit("stroke-drawn", newStroke) // so the client's `strokesArray` will be updated via v-model.
  *         2. localStrokesArray.push(newStroke) // so when the above change propagates back down, the strokesArray watcher ignores it. 
+ * 
+ * 3. The canvas resizes
+ *      HTML <canvas/> automatically wipes. However, our resize listener will 
+ *      re-render all the strokes on `strokesArray`. 
  * 
  * Therefore, strokesArray <=> UI. 
  */
@@ -92,15 +98,14 @@ export default {
         lineWidth: 2.5
       },
       isHoldingLeftClick: false,
-      touchDisabled: true, 
-      localStrokesArray: [...this.strokesArray], // ...creates a real copy, rather than an alias
+      onlyAllowApplePencil: true, 
+
+      // `[...strokesArray]` creates a fresh copy rather than an alias
+      localStrokesArray: [...this.strokesArray], 
       currentStroke: { 
         points: [] 
       },
-      currPoint: { 
-        x: 0, 
-        y: 0 
-      },
+      // initialize `prevPoint` to an invalid coordinate to signal that it's not defined initially
       prevPoint: { 
         x: -1, 
         y: -1 
@@ -113,21 +118,21 @@ export default {
     imageBlobUrl () {
       return this.imageBlob ? URL.createObjectURL(this.imageBlob) : "";
     },
-    isStrokeEraser () {
-      return this.currentTool.type === BlackboardTools.STROKE_ERASER;
+    isPen () {
+      return this.currentTool.type === BlackboardTools.PEN;
     },
     isNormalEraser () {
       return this.currentTool.type === BlackboardTools.NORMAL_ERASER;
     },
-    isPen () {
-      return this.currentTool.type === BlackboardTools.PEN;
+    isStrokeEraser () {
+      return this.currentTool.type === BlackboardTools.STROKE_ERASER;
     }
   },
   watch: {
     /**
      * Ensures `strokesArray => UI`, that is whenever the client mutates the `strokesArray` prop, we update <canvas/> accordingly`. 
      * 
-     * Note we must ignore the case where (n == this.localStrokesArray.length)
+     * Note we ignore the case where (n == this.localStrokesArray.length)
      * because it means that user drew on canvas --> emits event --> client changes --> triggers our own watch hook
      */
     strokesArray () {
@@ -137,7 +142,11 @@ export default {
         this.localStrokesArray = [];
       } else if (n - this.localStrokesArray.length === 1) { 
         const newStroke = this.strokesArray[n-1];
-        this.$_drawStroke(newStroke, this.$_getPointDuration(newStroke));
+        if (newStroke.startTime === newStroke.endTime) {
+          this.$_drawStroke(newStroke, null) // instantly
+        } else {
+          this.$_drawStroke(newStroke, this.$_getPointDuration(newStroke)); // smoothly 
+        }
         this.localStrokesArray.push(newStroke);
       } 
       this.checkRepInvariant(); 
@@ -147,6 +156,8 @@ export default {
     this.initializeCanvas();
     document.fonts.ready.then(this.createCustomCusor); // since cursor uses material icons font, load it after fonts are ready
     window.addEventListener("resize", this.resizeBlackboard, false); 
+    
+    // explicitly expose `getThumbnailBlob` to client components that use <BlackboardCoreDrawing/>
     this.$emit("mounted", { 
       getThumbnailBlob: this.getThumbnailBlob,
     }); 
@@ -155,31 +166,16 @@ export default {
     window.removeEventListener("resize", this.resizeBlackboard);
   },
   methods: {
-    checkRepInvariant () {
-      if (this.strokesArray.length !== this.localStrokesArray.length) {
-        throw new Error(
-          `Rep invariant broken: external, internal lengths are ${this.strokesArray.length}, ${this.localStrokesArray.length}`
-        );
-      }
-    },
-    // UI => strokesArray
-    saveStrokeThenReset (e) {
-      e.preventDefault()
-      // EDGE CASE: user is touching the screen despite that touch is disabled
-      if (this.currentStroke.points.length === 0) return;  
-
-      this.currentStroke.endTime = Number(this.currentTime.toFixed(1));
-      this.localStrokesArray.push(this.currentStroke);
-      this.$emit("stroke-drawn", this.currentStroke);
-      
-      // reset variables
-      this.currentStroke = { 
-        points: [] 
-      };
-      this.prevPoint = { 
-        x: -1, 
-        y: -1 
-      };
+    /** 
+     * Ensures UI => strokesArray
+     * 
+     * All tools (pen, normal eraser, stroke eraser) will generate strokes.  
+     * Because every stroke is processed here, UI => strokesArray.
+     */
+    handleEndOfStroke (newStroke) {
+      newStroke.id = getRandomId(); 
+      this.localStrokesArray.push(newStroke);
+      this.$emit("stroke-drawn", newStroke);
     },
     initializeCanvas () {
       this.canvas = this.$refs.FrontCanvas;
@@ -189,13 +185,148 @@ export default {
       this.resizeBlackboard();
       this.$_drawStrokesInstantly();
     },
-    changeTool (tool) {
-      this.currentTool = tool;
-      this.ctx.globalCompositeOperation = (this.isNormalEraser || this.isStrokeEraser) ? // isStrokeEraser now erases in the back like a normal eraser
-        "destination-out" : "source-over";
-      this.createCustomCusor();
+    /**
+     * 
+     * Mutates this.currentStroke
+     */
+    startNewStroke (e) {
+      e.preventDefault(); 
+
+      this.prevPoint = { // TODO: use an optional
+        x: -1, 
+        y: -1 
+      };
+      this.currentStroke = {
+        strokeNumber: this.strokesArray.length + 1,
+        startTime: Number(this.currentTime.toFixed(1)),
+        color: this.currentTool.color,
+        lineWidth: this.currentTool.lineWidth,
+        isErasing: this.isNormalEraser,
+        points: []
+      };
+
+      // TODO: This is a quickfix to prevent the pencil offset bug
+      if (this.$_rescaleCanvas()) {
+        this.$_drawStrokesInstantly();
+      }
     },
-    async resetBoard () {
+    touchStart (e) {
+      if (this.isNotValidTouch(e)) {
+        return; 
+      }
+      if (this.isDrawingWithApplePencil(e)) { 
+        // disable touch drawing so the user doesn't accidentally draw with his/her palm 
+        this.onlyAllowApplePencil = true; 
+      }
+      this.handleContactWithBlackboard(e, { isInitialContact: true });
+    },
+    mouseDown (e) {
+      this.isHoldingLeftClick = true;
+      this.handleContactWithBlackboard(e, { isInitialContact: true });
+    },
+    touchMove (e) {
+      if (this.isNotValidTouch(e)) {
+        return;  
+      }
+      this.handleContactWithBlackboard(e, { isInitialContact: false });
+    },
+    // TODO REFACTOR: can take an optional argument, and share the function with mouse and touch
+    mouseMove (e) {
+      if (!this.isHoldingLeftClick) {
+        return;
+      }
+      this.handleContactWithBlackboard(e, { isInitialContact: false });
+    },
+    /**
+     * TODO: Make `tool` an explicit parameter 
+     */
+    handleContactWithBlackboard (e, { isInitialContact }) {
+      e.preventDefault(); // don't know what will happen if e.preventDefault is here
+      const contactPoint = this.getStylusOrFingerOrMousePosition(e); // should make "isHoldingLeftClick" an explicit parameter
+      
+      if (this.isStrokeEraser) { 
+        this.eraseAllStrokesWithinRadius(e, contactPoint); 
+      } 
+      else {
+        if (isInitialContact) this.startNewStroke(e);
+        this.lengthenTheCurrentStroke(e, contactPoint);
+      }
+    },
+    lengthenTheCurrentStroke (e, contactPoint) {
+      // update state
+      this.currentStroke.points.push({ 
+        unitX: parseFloat(contactPoint.x / this.canvas.width).toFixed(4),
+        unitY: parseFloat(contactPoint.y / this.canvas.height).toFixed(4)
+      });
+
+      // update UI
+      if (this.prevPoint.x !== -1 && this.prevPoint.y !== -1) {
+        this.$_connectTwoPoints(
+          [this.normalizePoint(this.prevPoint), this.normalizePoint(contactPoint)], // `points`: note that the points have to be normalized for now before refactors
+          1, // `i`: note that setting i = 1 is a quick-fix (will refactor $_connectTwoPoints() in the future)
+          this.isNormalEraser || this.isStrokeEraser, // `isErasing`,
+          this.ctx,
+          this.currentTool.color,
+          this.currentTool.lineWidth,
+        );
+      }
+      this.prevPoint = contactPoint;
+    },
+    /**
+     * For each stroke that intersects with a circular region,
+     * draw an "anti-stroke" to effectively delete it. 
+     */
+    eraseAllStrokesWithinRadius (e, eraserPosition) {
+      for (const stroke of this.strokesArray) {
+        if (stroke.wasErased || stroke.isErasing) {  
+          continue;
+        }
+        for (const point of stroke.points) {
+          const deltaX = eraserPosition.x - point.unitX * this.canvas.width;
+          const deltaY = eraserPosition.y - point.unitY * this.canvas.height;
+          const radius = 10; 
+          if (Math.sqrt(deltaX**2 + deltaY**2) < radius) {
+            this.eraseStroke(stroke);
+            break; 
+          }
+        }
+      }
+    },
+    /**
+     * Create an anti-stroke that covers over another stroke, effectively erasing it. 
+     * 
+     * @param stroke the stroke to erase or cover over
+     * @effect mutates <canvas/> and `localStrokesArray` 
+     */
+    eraseStroke (stroke) {
+      // mark the stroke as erased so it can be ignored by future stroke erasers
+      stroke.wasErased = true;
+      const antiStroke = {
+        isErasing: true,
+        strokeNumber: this.strokesArray.length + 1,
+        lineWidth: stroke.lineWidth + 2,
+        points: stroke.points // points are normalized
+      };
+      this.$_drawStroke(antiStroke);
+      this.handleEndOfStroke(antiStroke);
+    },
+    mouseUp (e) {
+      this.isHoldingLeftClick = false;
+      this.handleLiftingContactFromBlackboard(e);
+    },
+    handleLiftingContactFromBlackboard (e) {
+      e.preventDefault(); 
+      // EDGE CASE: user is touching the screen despite that touch is disabled
+      if (this.currentStroke.points.length === 0) {
+        return; 
+      }
+      this.currentStroke.endTime = Number(this.currentTime.toFixed(1));
+      this.handleEndOfStroke(this.currentStroke);
+    },
+    /**
+     * Reset the state and UI of this component itself. 
+     */
+    async resetBlackboard () {
       this.wipeUI();
       this.resetVariables(); 
       this.$emit("board-reset");
@@ -213,192 +344,14 @@ export default {
       this.imageBlob = null;
     },
     /**
-     * By design, Handles the case if `imageFile` is empty.
-     */
-    handleImageFile (e) {
-      const imageFile = e.target.files[0]; 
-      if (!imageFile) return; 
-      if (imageFile.type.split("/")[0] !== "image") {
-        this.$root.$emit("show-snackbar", "Error: only image files are supported for now.");
-      } else {
-        this.displayImageFile(imageFile);
-      }
-    },
-    /**
-     * TODO: Is imageFile a Blob or File type? 
-     */
-    displayImageFile (imageFile) {
-      this.imageBlob = imageFile; 
-      this.$emit("update:bgImageBlob", this.imageBlob);
-      this.$_renderBackground(this.imageBlobUrl);
-    },
-    startNewStroke (e) {
-      this.$emit("stroke-start");
-      e.preventDefault(); 
-      
-      this.currentStroke = {
-        id: getRandomId(),
-        strokeNumber: this.strokesArray.length + 1,
-        startTime: Number(this.currentTime.toFixed(1)),
-        color: this.currentTool.color,
-        lineWidth: this.currentTool.lineWidth,
-        isErasing: this.isNormalEraser,
-        points: []
-      };
-      // TODO: ensure commenting out the below does not re-introduce the pencil offset bug
-      if (this.$_rescaleCanvas()) {
-        this.$_drawStrokesInstantly();
-      }
-      this.$_setStyle(this.currentTool.color, this.currentTool.lineWidth);
-    },
-    touchStart (e) {
-      if (this.isNotValidTouch(e)) return; 
-      if (e.touches[0].touchType === "stylus") { 
-        this.touchDisabled = true; 
-      }
-      if (this.isStrokeEraser) { 
-        this.eraseStrokesWithinRadius(e); 
-      } else {
-        this.startNewStroke(e);
-        this.drawToPointAndSave(e);
-      }
-    },
-    touchMove (e) {
-      if (this.isNotValidTouch(e)) return;  
-      if (this.isStrokeEraser) this.eraseStrokesWithinRadius(e); 
-      else this.drawToPointAndSave(e);  
-    },
-    touchEnd (e) { 
-      this.saveStrokeThenReset(e); 
-    },
-    mouseDown (e) {
-      this.isHoldingLeftClick = true;
-      if (this.isStrokeEraser) { 
-        this.eraseStrokesWithinRadius(e); 
-      } else {
-        this.startNewStroke(e);
-        const isMouse = true;
-        this.drawToPointAndSave(e, isMouse);
-      }
-    },
-    mouseMove (e) {
-      if (!this.isHoldingLeftClick) return; 
-      if (this.isStrokeEraser) { 
-        this.eraseStrokesWithinRadius(e); 
-      } else {
-        const isMouse = true;
-        this.drawToPointAndSave(e, isMouse);
-      }
-    },
-    mouseUp (e) {
-      this.isHoldingLeftClick = false;
-      this.saveStrokeThenReset(e);
-    },
-    drawToPointAndSave (e, isMouse) {
-      e.preventDefault();
-      if (isMouse) { 
-        this.currPoint = { 
-          x: e.offsetX, 
-          y: e.offsetY 
-        }; 
-      } else { 
-        this.getTouchPos(e); // mutates this.currPoint
-      }
-      this.convertAndSavePoint(this.currPoint.x, this.currPoint.y);
-      this.drawToPoint(this.currPoint);
-    },
-    convertAndSavePoint (x, y) {
-      const unitX = parseFloat(x / this.canvas.width).toFixed(4);
-      const unitY = parseFloat(y / this.canvas.height).toFixed(4);
-      this.currentStroke.points.push({ unitX, unitY });
-    },
-    eraseStrokesWithinRadius (e) {
-      e.preventDefault();
-      let eraserCenter = {};
-      if (this.isHoldingLeftClick) {
-        eraserCenter = { 
-          x: e.offsetX, 
-          y: e.offsetY 
-        };
-      } else {
-        const finger1 = e.touches[0];
-        const { left, top } = this.canvas.getBoundingClientRect();
-        eraserCenter = {
-          x: finger1.pageX - left - window.scrollX,
-          y: finger1.pageY - top - window.scrollY
-        };
-      }
-      for (let i = 0; i < this.strokesArray.length; i++) {
-        const stroke = this.strokesArray[i];
-        // don't undo eraser strokes
-        if (stroke.wasErased || stroke.isErasing) {  
-          continue;
-        }
-        for (const point of stroke.points) {
-          const deltaX = eraserCenter.x - point.unitX * this.canvas.width;
-          const deltaY = eraserCenter.y - point.unitY * this.canvas.height;
-          const radius = 10; 
-          if (Math.sqrt(deltaX**2 + deltaY**2) < radius) {
-            this.eraseStroke(stroke);
-            break; 
-          }
-        }
-      }
-    },
-    eraseStroke (stroke) {
-      stroke.wasErased = true;
-      this.$emit("stroke-start");
-
-      const antiStroke = {
-        id: getRandomId(),
-        strokeNumber: this.strokesArray.length + 1,
-        isErasing: true,
-        lineWidth: stroke.lineWidth + 2,
-        points: stroke.points
-      };
-
-      // TODO: refactor
-      this.$_drawStroke(antiStroke);
-      this.localStrokesArray.push(antiStroke);
-      this.$emit("stroke-drawn", antiStroke);
-    },
-    getTouchPos (e) {
-      const finger1 = e.touches[0];
-      const { left, top } = this.canvas.getBoundingClientRect();
-      this.currPoint.x = finger1.pageX - left - window.scrollX;
-      this.currPoint.y = finger1.pageY - top - window.scrollY;
-    },
-    isNotValidTouch (e) {
-      if (e.touches.length !== 1) return true; // multiple fingers not allowed
-      return this.isFinger(e) && this.touchDisabled;
-    },
-    isApplePencil (e) {
-      return e.touches[0].touchType === "stylus";
-    },
-    isFinger (e) { // not true: could be Surface pen
-      return e.touches[0].touchType !== "stylus";
-    },
-    drawToPoint ({ x, y }) {
-      if (this.prevPoint.x !== -1) { // start of stroke, don't connect previous points
-        this.traceLineTo(x, y);
-        this.ctx.stroke();
-      }
-      this.prevPoint = { x, y };
-    },
-    traceLineTo (x, y) {
-      this.ctx.beginPath();
-      this.ctx.moveTo(this.prevPoint.x, this.prevPoint.y);
-      this.ctx.lineTo(x, y);
-    },
-    /**
      * Generates a thumbnail by: 
      *   1. Render the background image / grey background on the back canvas 
      *   2. Then draw on the strokes on the back canvas as well
      * 
-     *   this implementation suffers from edge cases: 
-     *   If eraser strokes are ignored, then strokes covered by the normal eraser will then be visible when rendered as a thumbnail
-     *   I tried not using a background color, but then the white strokes will be invisible
-     *   I tried not ignoring eraser strokes, but then the eraser strokes will damage not only the strokes but the background as well
+     *   This implementation suffers from edge cases: 
+     *     If eraser strokes are ignored, then strokes covered by the normal eraser will then be visible when rendered as a thumbnail
+     *     I tried not using a background color, but then the white strokes will be invisible
+     *     I tried not ignoring eraser strokes, but then the eraser strokes will damage not only the strokes but the background as well
      */
     getThumbnailBlob () {
       return new Promise(async resolve => {
@@ -427,6 +380,26 @@ export default {
       this.$_rescaleCanvas();
       this.$_drawStrokesInstantly();
     },
+    /**
+     * By design, Handles the case if `imageFile` is empty.
+     */
+    handleImageFile (e) {
+      const imageFile = e.target.files[0]; 
+      if (!imageFile) return; 
+      if (imageFile.type.split("/")[0] !== "image") {
+        this.$root.$emit("show-snackbar", "Error: only image files are supported for now.");
+      } else {
+        this.displayImageFile(imageFile);
+      }
+    },
+    /**
+     * TODO: Is imageFile a Blob or File type?
+     */
+    displayImageFile (imageFile) {
+      this.imageBlob = imageFile; 
+      this.$emit("update:bgImageBlob", this.imageBlob);
+      this.$_renderBackground(this.imageBlobUrl);
+    },
     createCustomCusor () {
       const dummyCanvas = document.createElement("canvas");
       dummyCanvas.width = 24;
@@ -447,8 +420,69 @@ export default {
       window.scrollTo(0, document.body.scrollHeight) // to prevent being scrolled to the middle of page when Exiting the fullscreen
     },
     setTouchDisabled (newBoolean) {
-      this.touchDisabled = newBoolean; 
-    }
+      this.onlyAllowApplePencil = newBoolean; 
+    },
+    checkRepInvariant () {
+      if (this.strokesArray.length !== this.localStrokesArray.length) {
+        throw new Error(
+          `Rep invariant violated: external, internal lengths are ${this.strokesArray.length}, ${this.localStrokesArray.length}`
+        );
+      }
+    },
+    isNotValidTouch (e) {
+      // disallow drawing with multiple fingers 
+      if (e.touches.length !== 1) {
+        return true;
+      } 
+      if (this.onlyAllowApplePencil && !this.isDrawingWithApplePencil(e)) {
+        this.$root.$emit(
+          "show-snackbar", 
+          `To draw with your finger/stylus, press "Enable Touch" next to the eraser.`);
+        return true; 
+      }
+    },
+    /**
+     * Note that a Surface Pen will register as "touch" rather than "stylus" 
+     */
+    isDrawingWithApplePencil (e) {
+      return e.touches[0].touchType === "stylus";
+    },
+    /**
+     * Sets the current tool, which directly affects:
+     *   1. The behavior of `setStrokeProperties()`
+     *   2. The cursor icon (for laptop users)
+     */
+    changeTool (tool) {
+      this.currentTool = tool;
+      this.createCustomCusor();
+    },
+    /**
+     * Get (x, y) position of stylus/touch/mouse
+     */
+    getStylusOrFingerOrMousePosition(e) {
+      // mouse
+      if (this.isHoldingLeftClick) {
+        return { 
+          x: e.offsetX, 
+          y: e.offsetY 
+        };
+      } 
+      // stylus/finger
+      else {
+        const { left, top } = this.canvas.getBoundingClientRect();
+        return {
+          x: e.touches[0].pageX - left - window.scrollX,
+          y: e.touches[0].pageY - top - window.scrollY
+        };
+      }
+    },
+    normalizePoint ({ x, y }) {
+      return {
+        unitX: x / this.canvas.width,
+        unitY: y / this.canvas.height
+      };
+    },
+    // MIGHT BE USEFUL LATER TO REUSE DRAWINGS
     // convertAllStrokesToBeInitialStrokes () {
     //   for (const stroke of this.strokesArray) {
     //     [stroke.startTime, stroke.endTime] = [0, 0];

--- a/src/components/DoodleAnimation.vue
+++ b/src/components/DoodleAnimation.vue
@@ -203,7 +203,6 @@ export default {
     },
     async renderFrame ({ strokeIndex, pointIndex }, instantly=false) {
       const stroke = this.strokesArray[strokeIndex];
-      this.$_setStyle(stroke.color, stroke.lineWidth); // since multiple strokes can be drawn simultaneously.
       this.$_connectTwoPoints(stroke.points, pointIndex, stroke.isErasing);
       if (!instantly) {
         await new Promise(resolve => setTimeout(resolve, 10/this.playbackSpeed)); // Here the second parameter 10/this.playbackSpeed determines the number of frames rendered per second

--- a/src/components/DoodleVideo.vue
+++ b/src/components/DoodleVideo.vue
@@ -199,7 +199,6 @@ export default {
     },
     renderFrame ({ strokeIndex, pointIndex }) {
       const stroke = this.strokesArray[strokeIndex];
-      this.$_setStyle(stroke.color, stroke.lineWidth); // since multiple strokes can be drawn simultaneously.
       this.$_connectTwoPoints(stroke.points, pointIndex, stroke.isErasing);
     }
   }

--- a/src/components/DoodleVideo.vue
+++ b/src/components/DoodleVideo.vue
@@ -1,10 +1,13 @@
 <template>
   <div id="fullscreen-wrapper" @click="(e) => $_exitFullscreen(e)" :class="isFullScreen ? 'fullscreen-video' : 'video-wrapper'">
     <div ref="VideoWrapper" class="video-container">
+      <!-- VISUAL DISPLAY -->
       <div ref="CanvasWrapper" style="position: relative;">
         <canvas ref="FrontCanvas" class="front-canvas"></canvas>
         <canvas ref="BackCanvas" class="background-canvas"></canvas>
       </div>
+
+      <!-- AUDIO SLIDER -->
       <audio v-if="audioUrl && strokesArray.length > 0"
         :src="audioUrl" 
         @play="initSyncing()"

--- a/src/components/RealtimeBlackboard.vue
+++ b/src/components/RealtimeBlackboard.vue
@@ -1,26 +1,42 @@
 <template>
   <div>
     <p v-if="!hasFetchedStrokesFromDb">Loading the real-time blackboard...</p>
+
+    <!-- Blackboard -->
     <Blackboard v-else
-      :strokesArray="strokesArray" @stroke-drawn="stroke => uploadToDb(stroke)"
+      :strokesArray="strokesArray" @stroke-drawn="stroke => handleNewlyDrawnStroke(stroke)"
       isRealtime
       @mounted="({ getThumbnailBlob }) => blackboard.getThumbnailBlob = getThumbnailBlob"
       @update:currentTime="currentTime => blackboard.currentTime = currentTime"
       @update:bgImageBlob="blob => blackboard.bgImageBlob = blob"
       @update:audioBlob="blob => blackboard.audioBlob = blob"
       @record-end="handleRecordEnd()"
-      @board-reset="deleteAllStrokesFromDb()"
     >
       <template v-slot:blackboard-toolbar>
         <slot name="blackboard-toolbar">
 
         </slot> 
         <BaseButton @click="toggleChat()" icon="mdi-chat" :filled="messagesOpen">Chat</BaseButton>
-        <BaseButton @click="uploadExplanation()" icon="mdi-upload">Save Animation</BaseButton>
+        <BaseButton @click="uploadExplanation()" icon="mdi-upload">Save Blackboard</BaseButton>
       </template> 
-    </Blackboard> 
 
-     <v-dialog v-model="dialog" max-width="600">
+      <!-- Wipe Board (overrides the normal, offline wiping behavior) -->
+      <template v-slot:wipe-board-button-slot>
+        <BasePopupButton actionName="Wipe board" @action-do="deleteAllStrokesFromDb()">
+          <template v-slot:activator-button="{ on }">
+            <BaseButton :on="on" icon="mdi-delete" data-qa="wipe-board">
+              Wipe board
+            </BaseButton>
+          </template>
+          <template v-slot:message-to-user>
+            Are you sure you want to wipe everything?
+          </template> 
+        </BasePopupButton>
+      </template>
+    </Blackboard> 
+    
+    <!-- Popup for saving blackboard -->
+    <v-dialog v-model="dialog" max-width="600">
       <v-card>
         <v-card-title class="headline">Save your recorded explanation?</v-card-title>
         <v-card-text>
@@ -37,6 +53,8 @@
         </v-card-actions>
       </v-card>
     </v-dialog>
+
+    <!-- Realtime Messaging -->
     <RealtimeMessageChat
       v-model="messagesOpen"
       :roomParticipants="roomParticipants"
@@ -57,15 +75,13 @@
  *     strokesArray, which propagates to the Blackboard component
  * 
  * blackboard => database: 
- *     Whenever the user draws a new stroke, that stroke will be uploaded as a new document to the database. 
- *     Momentarily, there will be divergence between state and UI, which is to say that 
- *     the user's `strokesArray` does NOT have the new stroke, even though she was the one who drew the stroke.
- *     However, when the write operation finally resolves, everyone's `strokesArray` will be updated, 
- *     including the original author herself. Note that there will be double drawing, where the first is for feedback,
- *     and the second is to signal when other people can actually see her new stroke. 
+ *     Whenever the user draw a new stroke, it will be pushed to `strokesArray` and uploaded to Firestore. 
+ *     When the upload finishes, other people will detect the new stroke and update accordingly. 
+ *     (Note the user will ignore the new stroke, since he/she drew the stroke in the first place.)
  */
 import Blackboard from "@/components/Blackboard.vue"; 
 import BaseButton from "@/components/BaseButton.vue"; 
+import BasePopupButton from "@/components/BasePopupButton.vue";
 import RealtimeMessageChat from "@/components/RealtimeMessageChat.vue";
 import ExplUploadHelpers from "@/mixins/ExplUploadHelpers.js";
 import firebase from "firebase/app"; 
@@ -90,6 +106,7 @@ export default {
   components: {
     Blackboard,
     BaseButton,
+    BasePopupButton,
     RealtimeMessageChat
   },
   data () {
@@ -102,6 +119,7 @@ export default {
         getThumbnailBlob: null,
         currentTime: 0
       },
+      removeBlackboardStrokesListener: null,
       dialog: false,
       explTitle: "",
       classId: this.$route.params.class_id,
@@ -118,44 +136,92 @@ export default {
   created () {
     this.keepSyncingBoardWithDb(); 
   },
+  destroyed () {
+    this.removeBlackboardStrokesListener();
+  },
   methods: {
-    /*
-    TODO:
-      1. order by `timestamp` rather than `strokeNumber`
-      2. Investigate why each new stroke triggers 2-3 snapshot callbacks
-      3. handle a board reset more efficiently
+    /** 
+    Known issues:
+      1. [CRUCIAL] Investigate why each new stroke triggers 2-3 snapshot callbacks 
+      2. If the board is wiped while someone else is drawing, it results in diverging states
+
+      Overview of correctness argument: 
+        - If database has fewer strokes than the client, it must mean the board was wiped
+        - However, during the wiping process, other people could still be drawing 
+        - Therefore, the correct response is to first wipe the board, then render drawings
+          that other people made during the process (if any). 
+      @see explain.mit.edu/class/mDbUrvjy4pe8Q5s5wyoD/posts/k8TLymX9Say5EUoCdxEp
     */
     keepSyncingBoardWithDb () {
-      this.strokesRef.orderBy("strokeNumber").onSnapshot(snapshot => {
-        // detects if the blackboard was wiped
-        if (snapshot.docs.length === 0) {
-          this.strokesArray = [];
-        } else {
-          snapshot.docChanges().filter(change => change.type === "added").forEach(change => {
+      this.removeBlackboardStrokesListener = this.strokesRef.orderBy("timestamp").onSnapshot(async snapshot => {
+        // CASE 1: wipe board operation
+        const removedDocs = snapshot.docChanges().filter(change => change.type === "removed"); 
+        if (removedDocs.length > 0) {
+          this.$root.$emit("show-snackbar", "The board was wiped by someone.");
+          // trigger <Blackboard/> to wipe the canvas UI via resetting `strokesArray` 
+          this.strokesArray = []; 
+
+          /* Wait 1 tick, otherwise <Blackboard/> can't react to `this.strokesArray = []`,
+             because of Vue's reactivity caveat: "If the same watcher is triggered multiple times, it will be pushed into the queue only once."
+             More info here: https://vuejs.org/v2/guide/reactivity.html */
+          await this.$nextTick();
+
+        /* If people added strokes while Firestore was still deleting documents,
+           then the blackboard should NOT end up being empty. */
+         if (snapshot.docs.length > 0) {
+          snapshot.docs.forEach(doc => {
             this.strokesArray.push({
-              id: change.doc.id,
-              ...change.doc.data(),
+              id: doc.id,
+              ...doc.data(),
               startTime: this.blackboard.currentTime,
-              endTime: 1 + this.blackboard.currentTime // make other people's strokes have a period of 1 second
+              endTime: 1 + this.blackboard.currentTime
             });
           });
+         }
+        } 
+
+        // CASE 2: add stroke operation
+        else {
+          // CASE 2a: stroke added by the user himself/herself
+          if (snapshot.docs.length === this.strokesArray.length) {
+            console.log("my own stroke")
+            // do nothing
+          } 
+
+          // CASE 2b: stroke added by someone else 
+          else {
+            console.log("someone else's stroke");
+            snapshot.docChanges().filter(change => change.type === "added").forEach(change => {
+              this.strokesArray.push({
+                id: change.doc.id,
+                ...change.doc.data(),
+                startTime: this.blackboard.currentTime,
+                endTime: 1 + this.blackboard.currentTime // make other people's strokes have a period of 1 second
+              });
+            });
+          }
         }
         if (!this.hasFetchedStrokesFromDb) { 
           this.hasFetchedStrokesFromDb = true;
         }
       });
     },
-    toggleChat () {
-      this.messagesOpen = !this.messagesOpen;
+    /**
+     * Helps maintain the invariant that UI => RealtimeBlackboard's strokesArray,
+     * and uploads the new stroke to Firestore.
+     */
+    handleNewlyDrawnStroke (stroke) {
+      this.strokesArray.push(stroke); 
+      this.uploadToDb(stroke);
     },
     async uploadToDb (stroke) {
-      const timestamp = firebase.firestore.FieldValue.serverTimestamp();
       try {
-        this.strokesRef.add({
-          timestamp,
+        this.strokesRef.doc(stroke.id).set({
+          timestamp: firebase.firestore.FieldValue.serverTimestamp(),
           ...stroke
         });
-      } catch (error) {
+      } 
+      catch (error) {
         this.$root.$emit("show-snackbar", "Failed to upload stroke to database.");
       }
     },
@@ -172,6 +238,7 @@ export default {
       this.explTitle = ""; 
     },
     async deleteAllStrokesFromDb () {
+      console.log("deleteAllStrokesFromDb, strokesArray = ", this.strokesArray);
       const promises = [];
       const strokeDeleteRequests = [];
       let currentBatch = db.batch();
@@ -193,7 +260,7 @@ export default {
       //   this.roomRef.update({ imageUrl: "" })
       // );
       await Promise.all(promises);
-      this.$root.$emit("show-snackbar", "Successfully reset blackboard.");
+      console.log("finished deleting everything")
     },
     handleRecordEnd () {
       // ask if the user wants to save/discard the recorded explanation 
@@ -205,6 +272,9 @@ export default {
     },
     discardAudio () {
       this.dialog = false; 
+    },
+    toggleChat () {
+      this.messagesOpen = !this.messagesOpen;
     }
   }
 }


### PR DESCRIPTION
Fixed a range of concurrency issues:
  - Diverging UI when "wipe board" interleaves with "strokesArray.push()"
  - Interfering colors
  - Erasers for the real-time blackboard is very sluggish

Major refactors: 
  - Drastically simplify BlackboardCoreDrawing's methods 
  - All strokes in BlackboardCoreDrawing, whether it be generated by the stroke eraser, normal eraser or the pen, will be handled with an interfacing method. That means it's easy to argue correctness as the blackboard only supports adding strokes and resetting. 
 